### PR TITLE
Add node_modules to example directory option usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ multi-tool install ramda@0.23.x
 ramda@0.23.x
 $ multi-tool install ramda@latest
 ramda@latest
-$ multi-tool install ramda@latest --directory /path/to/project
+$ multi-tool install ramda@latest --directory /path/to/project/node_modules
 ramda@latest
 ```
 > __PROTIP:__ Any valid semver range that is also a valid \*nix directory name is supported.

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const cli = meow(`
     ramda@0.23.x
     $ ${name} install ramda@latest
     ramda@latest
-    $ ${name} install ramda@latest --directory /path/to/project
+    $ ${name} install ramda@latest --directory /path/to/project/node_modules
     ramda@latest
 `);
 


### PR DESCRIPTION
## Description
Usage examples of `--directory` should include `node_modules` lest users want to install packages in their project root 😬.