### PR TITLE
multi-tool@0.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "findup-sync": "0.4.x",
     "meow": "3.x",
-    "multi-tool": "0.0.x",
+    "multi-tool": "0.2.x",
     "ramda": "0.23.x",
     "valid-filename": "2.x"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -50,12 +50,11 @@ if (!validName(pkgName) || !validVersion(pkgVersion)) {
   cli.showHelp(3);
 }
 
-install(pkgName, pkgVersion, dir)
-  .then(installed => {
-    if (isNil(installed) || isEmpty(installed)) {
-      cli.showHelp(1);
-    } else {
-      console.log(installed);
-      process.exit(0);
-    }
-  });
+install(pkgName, pkgVersion, dir).then(installed => {
+  if (isNil(installed) || isEmpty(installed)) {
+    cli.showHelp(1);
+  } else {
+    console.log(installed);
+    process.exit(0);
+  }
+});

--- a/src/index.js
+++ b/src/index.js
@@ -11,13 +11,13 @@ const pkgRegex = /^(.+)@(.+)$/;
 const pkgLike = test(pkgRegex);
 
 const validCmd = anyPass([equals('install')]);
-const validDir = complement(isNil);
+const validPath = complement(isNil);
 const {validName, validVersion} = install;
 
 const name = 'multi-tool';
 const cli = meow(`
   Usage
-    $ ${name} install <<name>@<version>> [--directory <path>]
+    $ ${name} install <<name>@<version>> [--path <path>]
 
   Examples
     $ ${name} install ramda@0.23.0
@@ -26,21 +26,21 @@ const cli = meow(`
     ramda@0.23.x
     $ ${name} install ramda@latest
     ramda@latest
-    $ ${name} install ramda@latest --directory /path/to/project/node_modules
+    $ ${name} install ramda@latest --path /path/to/project/node_modules
     ramda@latest
 `);
 
 const cmd = cli.input[0];
 const pkg = cli.flags.package || cli.input[1];
-const directory = cli.flags.directory || cli.input[2];
+const path = cli.flags.path || cli.input[2];
 
-const dir = directory ? findup('node_modules', {cwd: directory}) : findup('node_modules');
+const pth = path ? findup('node_modules', {cwd: path}) : findup('node_modules');
 
 if (!validCmd(cmd)) {
   cli.showHelp(2);
 } else if (!pkgLike(pkg)) {
   cli.showHelp(3);
-} else if (!validDir(dir)) {
+} else if (!validPath(pth)) {
   cli.showHelp(4);
 }
 
@@ -50,7 +50,7 @@ if (!validName(pkgName) || !validVersion(pkgVersion)) {
   cli.showHelp(3);
 }
 
-install(pkgName, pkgVersion, dir).then(installed => {
+install(pkgName, pkgVersion, path).then(installed => {
   if (isNil(installed) || isEmpty(installed)) {
     cli.showHelp(1);
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
 const findup = require('findup-sync');
 const meow = require('meow');
 const install = require('multi-tool');
-const {allPass, anyPass, complement, equals, isNil, match, test} = require('ramda');
+const {allPass, anyPass, complement, equals, isEmpty, isNil, match, test} = require('ramda');
 const validFilename = require('valid-filename');
 
 const name = 'multi-tool';
@@ -36,11 +36,11 @@ const validCmd = anyPass([equals('install')]);
 const validDir = complement(isNil);
 const validPkg = allPass([validFilename, test(regexPkg)]);
 
-if (complement(validCmd)(cmd)) {
+if (!validCmd(cmd)) {
   cli.showHelp(2);
-} else if (complement(validPkg)(pkg)) {
+} else if (!validPkg(pkg)) {
   cli.showHelp(3);
-} else if (complement(validDir)(dir)) {
+} else if (!validDir(dir)) {
   cli.showHelp(4);
 }
 
@@ -48,7 +48,7 @@ const [, pkgName, pkgVersion] = match(regexPkg, pkg);
 
 install(pkgName, pkgVersion, dir)
   .then(installed => {
-    if (isNil(installed)) {
+    if (isNil(installed) || isEmpty(installed)) {
       cli.showHelp(1);
     } else {
       console.log(installed);

--- a/test/index.js
+++ b/test/index.js
@@ -55,11 +55,11 @@ test.serial('invalid package should exit 3', async t => {
   }
 });
 
-test.serial('invalid directory should exit 4', async t => {
+test.serial('invalid path should exit 4', async t => {
   t.plan(1);
 
   try {
-    await shell(`${cli} install ramda@0.23.0 --directory /tmp`);
+    await shell(`${cli} install ramda@0.23.0 --path /tmp`);
   } catch (err) {
     t.is(err.code, 4);
   }

--- a/test/index.js
+++ b/test/index.js
@@ -40,10 +40,16 @@ test.serial('invalid subcommand should exit 2', async t => {
 });
 
 test.serial('invalid package should exit 3', async t => {
-  t.plan(1);
+  t.plan(2);
 
   try {
     await shell(`${cli} install ramda`);
+  } catch (err) {
+    t.is(err.code, 3);
+  }
+
+  try {
+    await shell(`${cli} install 'ramda@>=0.23.0'`);
   } catch (err) {
     t.is(err.code, 3);
   }


### PR DESCRIPTION
## Description
Upgrade `multi-tool` version to `0.2.x`. Add stricter checks for package name and version before handing off to `multi-tool`. Change `directory` option name to `path`. 🎉 . 👍 . 🥇.